### PR TITLE
Change numeric chars to signed char for ARM compatibility

### DIFF
--- a/kociemba/ckociemba/coordcube.c
+++ b/kociemba/ckociemba/coordcube.c
@@ -20,10 +20,10 @@ short URtoDF_Move[N_URtoDF][N_MOVE] = {{0}};
 short URtoUL_Move[N_URtoUL][N_MOVE] = {{0}};
 short UBtoDF_Move[N_UBtoDF][N_MOVE] = {{0}};
 short MergeURtoULandUBtoDF[336][336] = {{0}};
-char Slice_URFtoDLF_Parity_Prun[N_SLICE2 * N_URFtoDLF * N_PARITY / 2] = {0};
-char Slice_URtoDF_Parity_Prun[N_SLICE2 * N_URtoDF * N_PARITY / 2] = {0};
-char Slice_Twist_Prun[N_SLICE1 * N_TWIST / 2 + 1] = {0};
-char Slice_Flip_Prun[N_SLICE1 * N_FLIP / 2] = {0};
+signed char Slice_URFtoDLF_Parity_Prun[N_SLICE2 * N_URFtoDLF * N_PARITY / 2] = {0};
+signed char Slice_URtoDF_Parity_Prun[N_SLICE2 * N_URtoDF * N_PARITY / 2] = {0};
+signed char Slice_Twist_Prun[N_SLICE1 * N_TWIST / 2 + 1] = {0};
+signed char Slice_Flip_Prun[N_SLICE1 * N_FLIP / 2] = {0};
 
 int PRUNING_INITED = 0;
 
@@ -256,7 +256,7 @@ void initPruning(const char *cache_dir)
         for (int i = 0; i < N_SLICE2 * N_URFtoDLF * N_PARITY / 2; i++)
             Slice_URFtoDLF_Parity_Prun[i] = -1;
         depth = 0;
-        setPruning(Slice_URFtoDLF_Parity_Prun, 0, (char) 0);
+        setPruning(Slice_URFtoDLF_Parity_Prun, 0, 0);
         done = 1;
         while (done != N_SLICE2 * N_URFtoDLF * N_PARITY) {
             for (int i = 0; i < N_SLICE2 * N_URFtoDLF * N_PARITY; i++) {
@@ -284,7 +284,7 @@ void initPruning(const char *cache_dir)
                             newParity = parityMove[parity][j];
                             if (getPruning(Slice_URFtoDLF_Parity_Prun, (N_SLICE2 * newURFtoDLF + newSlice) * 2 + newParity) == 0x0f) {
                                 setPruning(Slice_URFtoDLF_Parity_Prun, (N_SLICE2 * newURFtoDLF + newSlice) * 2 + newParity,
-                                        (char) (depth + 1));
+                                        (signed char) (depth + 1));
                                 done++;
                             }
                         }
@@ -300,7 +300,7 @@ void initPruning(const char *cache_dir)
         for (int i = 0; i < N_SLICE2 * N_URtoDF * N_PARITY / 2; i++)
             Slice_URtoDF_Parity_Prun[i] = -1;
         depth = 0;
-        setPruning(Slice_URtoDF_Parity_Prun, 0, (char) 0);
+        setPruning(Slice_URtoDF_Parity_Prun, 0, 0);
         done = 1;
         while (done != N_SLICE2 * N_URtoDF * N_PARITY) {
             for (int i = 0; i < N_SLICE2 * N_URtoDF * N_PARITY; i++) {
@@ -328,7 +328,7 @@ void initPruning(const char *cache_dir)
                             newParity = parityMove[parity][j];
                             if (getPruning(Slice_URtoDF_Parity_Prun, (N_SLICE2 * newURtoDF + newSlice) * 2 + newParity) == 0x0f) {
                                 setPruning(Slice_URtoDF_Parity_Prun, (N_SLICE2 * newURtoDF + newSlice) * 2 + newParity,
-                                        (char) (depth + 1));
+                                        (signed char) (depth + 1));
                                 done++;
                             }
                         }
@@ -344,7 +344,7 @@ void initPruning(const char *cache_dir)
         for (int i = 0; i < N_SLICE1 * N_TWIST / 2 + 1; i++)
             Slice_Twist_Prun[i] = -1;
         depth = 0;
-        setPruning(Slice_Twist_Prun, 0, (char) 0);
+        setPruning(Slice_Twist_Prun, 0, 0);
         done = 1;
         while (done != N_SLICE1 * N_TWIST) {
             for (int i = 0; i < N_SLICE1 * N_TWIST; i++) {
@@ -354,7 +354,7 @@ void initPruning(const char *cache_dir)
                         int newSlice = FRtoBR_Move[slice * 24][j] / 24;
                         int newTwist = twistMove[twist][j];
                         if (getPruning(Slice_Twist_Prun, N_SLICE1 * newTwist + newSlice) == 0x0f) {
-                            setPruning(Slice_Twist_Prun, N_SLICE1 * newTwist + newSlice, (char) (depth + 1));
+                            setPruning(Slice_Twist_Prun, N_SLICE1 * newTwist + newSlice, (signed char) (depth + 1));
                             done++;
                         }
                     }
@@ -369,7 +369,7 @@ void initPruning(const char *cache_dir)
         for (int i = 0; i < N_SLICE1 * N_FLIP / 2; i++)
             Slice_Flip_Prun[i] = -1;
         depth = 0;
-        setPruning(Slice_Flip_Prun, 0, (char) 0);
+        setPruning(Slice_Flip_Prun, 0, 0);
         done = 1;
         while (done != N_SLICE1 * N_FLIP) {
             for (int i = 0; i < N_SLICE1 * N_FLIP; i++) {
@@ -379,7 +379,7 @@ void initPruning(const char *cache_dir)
                         int newSlice = FRtoBR_Move[slice * 24][j] / 24;
                         int newFlip = flipMove[flip][j];
                         if (getPruning(Slice_Flip_Prun, N_SLICE1 * newFlip + newSlice) == 0x0f) {
-                            setPruning(Slice_Flip_Prun, N_SLICE1 * newFlip + newSlice, (char) (depth + 1));
+                            setPruning(Slice_Flip_Prun, N_SLICE1 * newFlip + newSlice, (signed char) (depth + 1));
                             done++;
                         }
                     }
@@ -393,7 +393,7 @@ void initPruning(const char *cache_dir)
     PRUNING_INITED = 1;
 }
 
-void setPruning(char *table, int index, char value) {
+void setPruning(signed char *table, int index, signed char value) {
     if ((index & 1) == 0)
         table[index / 2] &= 0xf0 | value;
     else
@@ -401,8 +401,8 @@ void setPruning(char *table, int index, char value) {
 }
 
 // Extract pruning value
-char getPruning(char *table, int index) {
-    char res;
+signed char getPruning(signed char *table, int index) {
+    signed char res;
 
     if ((index & 1) == 0)
         res = (table[index / 2] & 0x0f);

--- a/kociemba/ckociemba/cubiecube.c
+++ b/kociemba/ckociemba/cubiecube.c
@@ -5,30 +5,30 @@ cubiecube_t * get_moveCube()
 {
     static cubiecube_t moveCube[6];
     static int moveCube_initialized = 0;
-    static const corner_t   cpU[8]  = { UBR, URF, UFL, ULB, DFR, DLF, DBL, DRB };
-    static const char       coU[8]  = { 0, 0, 0, 0, 0, 0, 0, 0 };
-    static const edge_t     epU[12] = { UB, UR, UF, UL, DR, DF, DL, DB, FR, FL, BL, BR };
-    static const char       eoU[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    static const corner_t   cpR[8]  = { DFR, UFL, ULB, URF, DRB, DLF, DBL, UBR };
-    static const char       coR[8]  = { 2, 0, 0, 1, 1, 0, 0, 2 };
-    static const edge_t     epR[12] = { FR, UF, UL, UB, BR, DF, DL, DB, DR, FL, BL, UR };
-    static const char       eoR[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    static const corner_t   cpF[8]  = { UFL, DLF, ULB, UBR, URF, DFR, DBL, DRB };
-    static const char       coF[8]  = { 1, 2, 0, 0, 2, 1, 0, 0 };
-    static const edge_t     epF[12] = { UR, FL, UL, UB, DR, FR, DL, DB, UF, DF, BL, BR };
-    static const char       eoF[12] = { 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0 };
-    static const corner_t   cpD[8]  = { URF, UFL, ULB, UBR, DLF, DBL, DRB, DFR };
-    static const char       coD[8]  = { 0, 0, 0, 0, 0, 0, 0, 0 };
-    static const edge_t     epD[12] = { UR, UF, UL, UB, DF, DL, DB, DR, FR, FL, BL, BR };
-    static const char       eoD[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    static const corner_t   cpL[8]  = { URF, ULB, DBL, UBR, DFR, UFL, DLF, DRB };
-    static const char       coL[8]  = { 0, 1, 2, 0, 0, 2, 1, 0 };
-    static const edge_t     epL[12] = { UR, UF, BL, UB, DR, DF, FL, DB, FR, UL, DL, BR };
-    static const char       eoL[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    static const corner_t   cpB[8]  = { URF, UFL, UBR, DRB, DFR, DLF, ULB, DBL };
-    static const char       coB[8]  = { 0, 0, 1, 2, 0, 0, 2, 1 };
-    static const edge_t     epB[12] = { UR, UF, UL, BR, DR, DF, DL, BL, FR, FL, UB, DB };
-    static const char       eoB[12] = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1 };
+    static const corner_t     cpU[8]  = { UBR, URF, UFL, ULB, DFR, DLF, DBL, DRB };
+    static const signed char  coU[8]  = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    static const edge_t       epU[12] = { UB, UR, UF, UL, DR, DF, DL, DB, FR, FL, BL, BR };
+    static const signed char  eoU[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    static const corner_t     cpR[8]  = { DFR, UFL, ULB, URF, DRB, DLF, DBL, UBR };
+    static const signed char  coR[8]  = { 2, 0, 0, 1, 1, 0, 0, 2 };
+    static const edge_t       epR[12] = { FR, UF, UL, UB, BR, DF, DL, DB, DR, FL, BL, UR };
+    static const signed char  eoR[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    static const corner_t     cpF[8]  = { UFL, DLF, ULB, UBR, URF, DFR, DBL, DRB };
+    static const signed char  coF[8]  = { 1, 2, 0, 0, 2, 1, 0, 0 };
+    static const edge_t       epF[12] = { UR, FL, UL, UB, DR, FR, DL, DB, UF, DF, BL, BR };
+    static const signed char  eoF[12] = { 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0 };
+    static const corner_t     cpD[8]  = { URF, UFL, ULB, UBR, DLF, DBL, DRB, DFR };
+    static const signed char  coD[8]  = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    static const edge_t       epD[12] = { UR, UF, UL, UB, DF, DL, DB, DR, FR, FL, BL, BR };
+    static const signed char  eoD[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    static const corner_t     cpL[8]  = { URF, ULB, DBL, UBR, DFR, UFL, DLF, DRB };
+    static const signed char  coL[8]  = { 0, 1, 2, 0, 0, 2, 1, 0 };
+    static const edge_t       epL[12] = { UR, UF, BL, UB, DR, DF, FL, DB, FR, UL, DL, BR };
+    static const signed char  eoL[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    static const corner_t     cpB[8]  = { URF, UFL, UBR, DRB, DFR, DLF, ULB, DBL };
+    static const signed char  coB[8]  = { 0, 0, 1, 2, 0, 0, 2, 1 };
+    static const edge_t       epB[12] = { UR, UF, UL, BR, DR, DF, DL, BL, FR, FL, UB, DB };
+    static const signed char  eoB[12] = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1 };
 
     if (!moveCube_initialized) {
         memcpy(moveCube[0].cp, cpU, sizeof(cpU));
@@ -65,9 +65,9 @@ cubiecube_t* get_cubiecube()
     cubiecube_t* result = (cubiecube_t *) calloc(1, sizeof(cubiecube_t));
 
     static const corner_t   cp[8]   = { URF, UFL, ULB, UBR, DFR, DLF, DBL, DRB };
-    static const char       co[8]   = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    static const signed char       co[8]   = { 0, 0, 0, 0, 0, 0, 0, 0 };
     static const edge_t     ep[12]  = { UR, UF, UL, UB, DR, DF, DL, DB, FR, FL, BL, BR };
-    static const char       eo[12]  = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    static const signed char       eo[12]  = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
     memcpy(result->cp, cp, sizeof(cp));
     memcpy(result->co, co, sizeof(co));
@@ -133,7 +133,7 @@ facecube_t* toFaceCube(cubiecube_t* cubiecube)
     for(int i = 0; i < CORNER_COUNT; i++) {
         int j = cubiecube->cp[i];// cornercubie with index j is at
         // cornerposition with index i
-        char ori = cubiecube->co[i];// Orientation of this cubie
+        signed char ori = cubiecube->co[i];// Orientation of this cubie
         for (int n = 0; n < 3; n++)
             fcRet->f[cornerFacelet[i][(n + ori) % 3]] = cornerColor[j][n];
     }
@@ -141,7 +141,7 @@ facecube_t* toFaceCube(cubiecube_t* cubiecube)
     {
         int j = cubiecube->ep[i];// edgecubie with index j is at edgeposition
         // with index i
-        char ori = cubiecube->eo[i];// Orientation of this cubie
+        signed char ori = cubiecube->eo[i];// Orientation of this cubie
         for (int n = 0; n < 2; n++)
             fcRet->f[edgeFacelet[i][(n + ori) % 2]] = edgeColor[j][n];
     }
@@ -151,17 +151,17 @@ facecube_t* toFaceCube(cubiecube_t* cubiecube)
 void cornerMultiply(cubiecube_t* cubiecube, cubiecube_t* b)
 {
     corner_t cPerm[8] = {0};
-    char cOri[8] = {0};
+    signed char cOri[8] = {0};
     for (int corn = 0; corn < CORNER_COUNT; corn++) {
         cPerm[corn] = cubiecube->cp[b->cp[corn]];
 
-        char oriA = cubiecube->co[b->cp[corn]];
-        char oriB = b->co[corn];
-        char ori = 0;
+        signed char oriA = cubiecube->co[b->cp[corn]];
+        signed char oriB = b->co[corn];
+        signed char ori = 0;
 
         if (oriA < 3 && oriB < 3) // if both cubes are regular cubes...
         {
-            ori = (char) (oriA + oriB); // just do an addition modulo 3 here
+            ori = oriA + oriB; // just do an addition modulo 3 here
             if (ori >= 3)
                 ori -= 3; // the composition is a regular cube
 
@@ -169,19 +169,19 @@ void cornerMultiply(cubiecube_t* cubiecube, cubiecube_t* b)
         } else if (oriA < 3 && oriB >= 3) // if cube b is in a mirrored
         // state...
         {
-            ori = (char) (oriA + oriB);
+            ori = oriA + oriB;
             if (ori >= 6)
                 ori -= 3; // the composition is a mirrored cube
         } else if (oriA >= 3 && oriB < 3) // if cube a is an a mirrored
         // state...
         {
-            ori = (char) (oriA - oriB);
+            ori = oriA - oriB;
             if (ori < 3)
                 ori += 3; // the composition is a mirrored cube
         } else if (oriA >= 3 && oriB >= 3) // if both cubes are in mirrored
         // states...
         {
-            ori = (char) (oriA - oriB);
+            ori = oriA - oriB;
             if (ori < 0)
                 ori += 3; // the composition is a regular cube
             // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -197,11 +197,11 @@ void cornerMultiply(cubiecube_t* cubiecube, cubiecube_t* b)
 void edgeMultiply(cubiecube_t* cubiecube, cubiecube_t* b)
 {
     edge_t ePerm[12] = {0};
-    char eOri[12] = {0};
+    signed char eOri[12] = {0};
 
     for(int edge = 0; edge < EDGE_COUNT; edge++) {
         ePerm[edge] = cubiecube->ep[b->ep[edge]];
-        eOri[edge] = (char) ((b->eo[edge] + cubiecube->eo[b->ep[edge]]) % 2);
+        eOri[edge] = (b->eo[edge] + cubiecube->eo[b->ep[edge]]) % 2;
     }
     for(int e = 0; e < EDGE_COUNT; e++) {
         cubiecube->ep[e] = ePerm[e];
@@ -224,12 +224,12 @@ void invCubieCube(cubiecube_t* cubiecube, cubiecube_t* c)
     for (int corn = 0; corn < CORNER_COUNT; corn++)
         c->cp[cubiecube->cp[corn]] = corn;
     for (int corn = 0; corn < CORNER_COUNT; corn++) {
-        char ori = cubiecube->co[c->cp[corn]];
+        signed char ori = cubiecube->co[c->cp[corn]];
         if (ori >= 3)// Just for completeness. We do not invert mirrored
             // cubes in the program.
             c->co[corn] = ori;
         else {// the standard case
-            c->co[corn] = (char) -ori;
+            c->co[corn] = -ori;
             if (c->co[corn] < 0)
                 c->co[corn] += 3;
         }
@@ -248,10 +248,10 @@ void setTwist(cubiecube_t* cubiecube, short twist)
 {
     int twistParity = 0;
     for (int i = DRB - 1; i >= URF; i--) {
-        twistParity += cubiecube->co[i] = (char) (twist % 3);
+        twistParity += cubiecube->co[i] = (signed char) (twist % 3);
         twist /= 3;
     }
-    cubiecube->co[DRB] = (char) ((3 - twistParity % 3) % 3);
+    cubiecube->co[DRB] = (signed char) ((3 - twistParity % 3) % 3);
 }
 
 short getFlip(cubiecube_t* cubiecube)
@@ -266,10 +266,10 @@ void setFlip(cubiecube_t* cubiecube, short flip)
 {
     int flipParity = 0;
     for (int i = BR - 1; i >= UR; i--) {
-        flipParity += cubiecube->eo[i] = (char) (flip % 2);
+        flipParity += cubiecube->eo[i] = (signed char) (flip % 2);
         flip /= 2;
     }
-    cubiecube->eo[BR] = (char) ((2 - flipParity % 2) % 2);
+    cubiecube->eo[BR] = (signed char) ((2 - flipParity % 2) % 2);
 }
 
 short cornerParity(cubiecube_t* cubiecube)

--- a/kociemba/ckociemba/facecube.c
+++ b/kociemba/ckociemba/facecube.c
@@ -81,7 +81,7 @@ void to_String(facecube_t* facecube, char* res)
 
 cubiecube_t* toCubieCube(facecube_t* facecube)
 {
-    unsigned char ori;
+    signed char ori;
     cubiecube_t* ccRet = (cubiecube_t*) calloc(1, sizeof(cubiecube_t));
     for (int i = 0; i < 8; i++)
         ccRet->cp[i] = URF;// invalidate corners
@@ -100,7 +100,7 @@ cubiecube_t* toCubieCube(facecube_t* facecube)
             if (col1 == cornerColor[j][1] && col2 == cornerColor[j][2]) {
                 // in cornerposition i we have cornercubie j
                 ccRet->cp[i] = j;
-                ccRet->co[i] = (char) (ori % 3);
+                ccRet->co[i] = ori % 3;
                 break;
             }
         }

--- a/kociemba/ckociemba/include/coordcube.h
+++ b/kociemba/ckociemba/include/coordcube.h
@@ -84,28 +84,28 @@ extern short MergeURtoULandUBtoDF[336][336];
 
 // Pruning table for the permutation of the corners and the UD-slice edges in phase2.
 // The pruning table entries give a lower estimation for the number of moves to reach the solved cube.
-extern char Slice_URFtoDLF_Parity_Prun[N_SLICE2 * N_URFtoDLF * N_PARITY / 2];
+extern signed char Slice_URFtoDLF_Parity_Prun[N_SLICE2 * N_URFtoDLF * N_PARITY / 2];
 
 // Pruning table for the permutation of the edges in phase2.
 // The pruning table entries give a lower estimation for the number of moves to reach the solved cube.
-extern char Slice_URtoDF_Parity_Prun[N_SLICE2 * N_URtoDF * N_PARITY / 2];
+extern signed char Slice_URtoDF_Parity_Prun[N_SLICE2 * N_URtoDF * N_PARITY / 2];
 
 // Pruning table for the twist of the corners and the position (not permutation) of the UD-slice edges in phase1
 // The pruning table entries give a lower estimation for the number of moves to reach the H-subgroup.
-extern char Slice_Twist_Prun[N_SLICE1 * N_TWIST / 2 + 1];
+extern signed char Slice_Twist_Prun[N_SLICE1 * N_TWIST / 2 + 1];
 
 // Pruning table for the flip of the edges and the position (not permutation) of the UD-slice edges in phase1
 // The pruning table entries give a lower estimation for the number of moves to reach the H-subgroup.
-extern char Slice_Flip_Prun[N_SLICE1 * N_FLIP / 2];
+extern signed char Slice_Flip_Prun[N_SLICE1 * N_FLIP / 2];
 
 extern int PRUNING_INITED;
 void initPruning(const char *cache_dir);
 
 // Set pruning value in table. Two values are stored in one char.
-void setPruning(char *table, int index, char value);
+void setPruning(signed char *table, int index, signed char value);
 
 // Extract pruning value
-char getPruning(char *table, int index);
+signed char getPruning(signed char *table, int index);
 
 coordcube_t* get_coordcube(cubiecube_t* cubiecube);
 void move(coordcube_t* coordcube, int m, const char *cache_dir);

--- a/kociemba/ckociemba/include/cubiecube.h
+++ b/kociemba/ckociemba/include/cubiecube.h
@@ -13,11 +13,11 @@ struct cubiecube {
     // corner permutation
     corner_t cp[8];
     // corner orientation
-    char co[8];
+    signed char co[8];
     // edge permutation
     edge_t ep[12];
     // edge orientation
-    char eo[12];
+    signed char eo[12];
 };
 typedef struct cubiecube cubiecube_t;
 


### PR DESCRIPTION
On ARM char is 'unsigned char', not 'signed char'. Therefore numeric values have to use 'signed char' explicitly, otherwise functions like invCubieCube() are broken.
