### PR TITLE
Remove several warnings

### DIFF
--- a/kociemba/build_ckociemba.py
+++ b/kociemba/build_ckociemba.py
@@ -32,7 +32,7 @@ ffi.set_source(
         'kociemba/ckociemba/cubiecube.c',
         'kociemba/ckociemba/facecube.c',
         'kociemba/ckociemba/search.c'],
-    extra_compile_args=['-std=c99', '-O3'])
+    extra_compile_args=['-std=c99', '-O3', '-D_XOPEN_SOURCE=700'])
 
 ffi.cdef("char* solve(char *cubestring, char *patternstring, char *cache_dir);")
 

--- a/kociemba/ckociemba/coordcube.c
+++ b/kociemba/ckociemba/coordcube.c
@@ -81,7 +81,8 @@ int check_cached_table(const char* name, void* ptr, int len, const char *cache_d
 void read_from_file(void* ptr, int len, const char* name)
 {
     FILE* f = fopen(name, "r");
-    fread(ptr, len, 1, f);
+    if (!fread(ptr, len, 1, f))
+        ((void)0); // suppress -Wunused-result warning
     fclose(f);
 }
 

--- a/kociemba/ckociemba/include/cubiecube.h
+++ b/kociemba/ckociemba/include/cubiecube.h
@@ -25,8 +25,8 @@ typedef struct cubiecube cubiecube_t;
 struct facecube;
 
 // this CubieCube array represents the 6 basic cube moves
-cubiecube_t* get_moveCube();
-cubiecube_t* get_cubiecube();
+cubiecube_t* get_moveCube(void);
+cubiecube_t* get_cubiecube(void);
 
 // n choose k
 int Cnk(int n, int k);

--- a/kociemba/ckociemba/include/facecube.h
+++ b/kociemba/ckociemba/include/facecube.h
@@ -32,7 +32,7 @@ extern color_t cornerColor[8][3];
 // Map the edge positions to facelet colors.
 extern color_t edgeColor[12][2];
 
-facecube_t* get_facecube();
+facecube_t* get_facecube(void);
 facecube_t* get_facecube_fromstring(char* cubeString);
 
 void to_String(facecube_t* facecube, char* res);

--- a/kociemba/ckociemba/include/search.h
+++ b/kociemba/ckociemba/include/search.h
@@ -17,7 +17,7 @@ typedef struct {
     int minDistPhase2[31];
 } search_t;
 
-search_t* get_search();
+search_t* get_search(void);
 
 // generate the solution string from the array data including a separator between phase1 and phase2 moves
 char* solutionToString(search_t* search, int length, int depthPhase1);


### PR DESCRIPTION
Adds (void) to the declaration of functions without arguments to avoid strict-prototypes warnings. Adds -D_XOPEN_SOURCE=700 to compile flags for proper strnlen() declaration. Adds dummy if-clause to avoid warning about ignored return value of fread().
