### PR TITLE
fix pip installing the library in python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 import os
+import io
 
 from setuptools import setup
 
-long_description = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
+long_description = io.open(os.path.join(os.path.dirname(__file__), 'README.md'), encoding='utf-8').read()
 
 setup(
     name='kociemba',


### PR DESCRIPTION
This fixes the installation process for Python3. This is what I was getting before this fix:
```bash
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-xogkhbdz/kociemba/setup.py", line 5, in <module>
        long_description = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
      File "/home/pi/.venv/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 4166: ordinal not in range(128)
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-xogkhbdz/kociemba/
```

Also, I had to use the `io` module to make it compatible with Python 2.x too.