### PR TITLE
Fix "This CFFI feature requires distutils. Please install the distutils or setuptools package."

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     entry_points = {
         'console_scripts': ['kociemba=kociemba.command_line:main'],
     },
-    setup_requires=['pytest-runner', "cffi>=1.0.0"],
+    setup_requires=['pytest-runner', "cffi>=1.0.0", "setuptools < 74"],
     tests_require=['pytest', ],
     zip_safe=False,
     cffi_modules=["kociemba/build_ckociemba.py:ffi"],


### PR DESCRIPTION
I don't know why this isn't a blocker on your runners, but when trying to build the thing locally this issue *kills* me.